### PR TITLE
Update fn_cleanupBase.sqf

### DIFF
--- a/server_addon_code/a3_zcp_exile/functions/fn_cleanupBase.sqf
+++ b/server_addon_code/a3_zcp_exile/functions/fn_cleanupBase.sqf
@@ -1,3 +1,25 @@
+private ["_location","_pos","_nil","_position","_nearPlayers","_positionX","_positionNew"];
+_location = [];
 {
+	_pos = getPosATL _x;
+	_location pushBackUnique _pos;
 	_nil = deleteVehicle _x;
 }count _this;
+
+_position = _location select 0;
+_nearPlayers = [];
+_nearPlayers = _position nearObjects ["Man", 100];
+if !(_nearPlayers isEqualTo []) then
+{
+	{
+		if !(alive _x) then
+		{
+			_positionX = getPosATL _x;
+			if ((_positionX select 2 > 1) && !(isTouchingGround _x)) then
+			{
+				_positionNew = [(_positionX select 0),(_positionX select 1), 0] findEmptyPosition [0,30];
+				_x setPosATL _positionNew;
+			};
+		};
+	} forEach _nearPlayers;
+};


### PR DESCRIPTION
If players die at ZCP after completion, in a tower for example, this will lower their corpse to the ground so fixed floating corpses on ZCP missions.